### PR TITLE
ci: add release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary

`release-please-config.json` already exists but nothing drives it — Release Please config without the workflow is a silent no-op. Adds `googleapis/release-please-action@v4` on push to `main`, using the `PAT` secret so the release PR can trigger `ci.yml` (default `GITHUB_TOKEN` can't fan out to other workflows).

## Why now

Fleet audit across `~/projects` found **0** repos with working Release Please pipelines — 5 had config, none had the workflow. Upstream fix in [Roxabi/roxabi-plugins#104](https://github.com/Roxabi/roxabi-plugins/pull/104) prevents the gap for future `/init` runs; this PR backfills the workflow for `roxabi-vault`.

## Test plan

- [ ] CI green on this PR
- [ ] After staging → main promotion, the next Conventional Commit on `main` triggers the release-please Action

🤖 Generated with [Claude Code](https://claude.com/claude-code)